### PR TITLE
Implement 'From' to 'Revision'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centraldogma"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Hoang Luu <luu.hoang@linecorp.com>"]
 edition = "2021"
 description = "CentralDogma client for Rust"

--- a/src/model.rs
+++ b/src/model.rs
@@ -40,6 +40,13 @@ impl AsRef<Option<i64>> for Revision {
     }
 }
 
+/// Create a new instance with the specified revision number.
+impl From<i64> for Revision {
+    fn from(value: i64) -> Self {
+        Self(Some(value))
+    }
+}
+
 impl Revision {
     /// Revision `-1`, also known as `HEAD`.
     pub const HEAD: Revision = Revision(Some(-1));
@@ -47,11 +54,6 @@ impl Revision {
     pub const INIT: Revision = Revision(Some(1));
     /// Omitted revision, behavior is decided on server side, usually [`Revision::HEAD`]
     pub const DEFAULT: Revision = Revision(None);
-
-    /// Create a new instance with the specified revision number.
-    pub fn from(i: i64) -> Self {
-        Revision(Some(i))
-    }
 }
 
 /// Creator of a project or repository or commit

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -123,7 +123,7 @@ fn watch_file_stream_test<'a>(
             content: ChangeContent::UpsertJson(json!({"a": "c"})),
         }];
         let new_push = async move {
-            tokio::time::sleep(Duration::from_millis(1)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
             r.push(Revision::HEAD, new_commit_msg, new_change).await
         };
 
@@ -170,7 +170,7 @@ fn watch_repo_stream_test<'a>(
             content: ChangeContent::UpsertJson(json!({"a": "c"})),
         }];
         let new_push = async move {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
             r.push(Revision::HEAD, new_commit_msg, new_change).await
         };
 


### PR DESCRIPTION
Close #8

## Changes
- Implement `From<i64>` for `Revision`
- Change sleep duration of push request in `watch` integration test

## Background
I implemented `From` trait for `Revision` because it provides exactly same method as well as `-1.into()` conversion.

And I also change the sleep durations in `watch` integration test because in my local environment, the test keeps failing due to `watch_stream` not dispatching any result for 10s.